### PR TITLE
Fixed a bug that was causing incorrect Search Results

### DIFF
--- a/SearchDialog.py
+++ b/SearchDialog.py
@@ -306,7 +306,7 @@ class SearchDialog(wx.Dialog):
                                 # We can identify the parent node using the map dictionary
                                 parentItem = mapDict[dParentCollNo]
 
-#                                print "SearchDialog.__init__(): ", dCollNo, dCollID, dParentCollNo, "*** ADDED ***"
+                                ## print "SearchDialog.__init__(): ", dCollNo, dCollID, dParentCollNo, "*** ADDED ***"
 
                                 # Create a new Checkbox Node for the current item a a child to the Parent Node
                                 item = self.ctcCollections.AppendItem(parentItem, dCollID, ct_type=CT.TREE_ITEMTYPE_CHECK)
@@ -317,7 +317,7 @@ class SearchDialog(wx.Dialog):
                                 # Check the item
                                 self.ctcCollections.CheckItem(item, True)
                                 # Set the item's PyData to the Collection Number
-                                self.ctcCollections.SetPyData(item, collNo)
+                                self.ctcCollections.SetPyData(item, dCollNo)
                                 # Add the new node to the map dictionary
                                 mapDict[dCollNo] = item
                                 # We need to indicate to the while loop that we found an entry that could be the parent of other entries
@@ -334,7 +334,7 @@ class SearchDialog(wx.Dialog):
                 # If the Collection's parent is not yet in the Collection tree or the Map dictionary ...
                 else:
 
-#                    print "SearchDialog.__init__(): ", collNo, collID, parentCollNo, "*** DEFERRED ***"
+                    ## print "SearchDialog.__init__(): ", collNo, collID, parentCollNo, "*** DEFERRED ***"
 
                     # ... we need to place that collection in the list of items to process later, once the parent Collection
                     # has been added to the database tree

--- a/XMLImport.py
+++ b/XMLImport.py
@@ -1111,6 +1111,7 @@ class XMLImport(Dialogs.GenForm):
                                    # Add the intervention information to the error message
                                    msg = msg + '\n' +  prompt % self.XMLFile.GetValue() + '\n' + \
                                                        prompt2 % (objectType, lineCount)
+                                   msg += u"\n\n%s\n%s" % (sys.exc_info()[0], sys.exc_info()[1])
                                # Display our carefully crafted error message to the user.
                                errordlg = Dialogs.ErrorDialog(None, msg, includeSkipCheck=skipCheck)
                                errordlg.ShowModal()


### PR DESCRIPTION
If you nested an existing collection within a newer collection,
collections in that part of the nesting structure on the Search Form
were probably not included in the Search Query.
Also made the XMLImport error message more informative by including the
exception raised.