### PR TITLE
Transcription issue fixed

### DIFF
--- a/RichTextEditCtrl_RTC.py
+++ b/RichTextEditCtrl_RTC.py
@@ -168,6 +168,9 @@ class RichTextEditCtrl(richtext.RichTextCtrl):
         self.txtOriginalAttr.SetFontStyle(wx.FONTSTYLE_NORMAL)
         self.txtOriginalAttr.SetFontUnderlined(False)
 
+        # Set the initial Style before Time Codes
+        self.StyleBeforeTimeCode = self.txtOriginalAttr
+
         # Define the style for Time Codes
         self.txtTimeCodeAttr = richtext.RichTextAttr()
         self.txtTimeCodeAttr.SetTextColour(wx.Colour(255,0,0))
@@ -1065,11 +1068,7 @@ class RichTextEditCtrl(richtext.RichTextCtrl):
             self.SetTxtStyle(fontBold = setting)
 
         try:
-
-            print "RichTextEditCtrl_RTC.SetBold():", self.parent.toolbar.GetToolState(self.parent.parent.parent.parent.CMD_BOLD_ID), setting
-        
             self.parent.toolbar.ToggleTool(self.parent.parent.parent.parent.CMD_BOLD_ID, setting)
-
         except:
             print sys.exc_info()[0]
             print sys.exc_info()[1]
@@ -1379,11 +1378,11 @@ class RichTextEditCtrl(richtext.RichTextCtrl):
             # ... don't edit this!
             return
         # Get the current Style
-        tmpStyle = self.GetDefaultStyle()
+        self.StyleBeforeTimeCode = self.GetDefaultStyle()
         # Check to see if tmpStyle is GOOD.
-        if not tmpStyle.GetFont().IsOk():
+        if not self.StyleBeforeTimeCode.GetFont().IsOk():
             # If not, use the current font
-            tmpStyle = self.txtAttr
+            self.StyleBeforeTimeCode = self.txtAttr
         # ... batch the undo
         self.BeginBatchUndo('InsertTimeCode')
         # Set the Style to TimeCode Style
@@ -1395,7 +1394,7 @@ class RichTextEditCtrl(richtext.RichTextCtrl):
         # Insert the hidden time code data
         self.WriteText('<%d> ' % timecode)
         # Return the Style to whatever it was before
-        self.SetDefaultStyle(tmpStyle)
+        self.SetDefaultStyle(self.StyleBeforeTimeCode)
         # End the Undo batch
         self.EndBatchUndo()
         # Let's ALWAYS leave the program focus in the Transcript after adding a time code.
@@ -2041,9 +2040,28 @@ class RichTextEditCtrl(richtext.RichTextCtrl):
             # ... update the style to the style at the new position
             self.txtAttr = self.GetStyleAt(ip)
 
-##        print "RichTextEditCtrl.OnKeyUp()", ip
+##        print "RichTextEditCtrl.OnKeyUp()", ip, self.GetLength()
 ##        self.PrintTextAttr("RichTextEditCtrl.OnKeyUp()", self.txtAttr)
 ##        print
+
+        # NOTE:  This code shouldn't have to exist.  It's too late here!!
+        #
+        #If we are typing but detect that we are not DISPLAYING characters correctly ...
+        if self.CompareFormatting(self.txtAttr, self.txtHiddenAttr, fullCompare=False):
+
+##            print "***  HIDDEN STYLE ***", self.GetCharAt(ip - 3), self.GetCharAt(ip - 2), self.GetCharAt(ip - 1), ip, self.GetLastPosition(), '         ',
+
+            # ... if there is a character before the current insertion point ...
+            if (ip > 2) and (self.GetCharAt(ip - 2) != 62):
+                # ... apply the Style from Before Time Codes to that character so it will NOT be hidden
+                self.SetStyle((ip - 1, ip), self.StyleBeforeTimeCode)
+                # Now set the current default style to the Style Before Time Codes.
+                self.SetDefaultStyle(self.StyleBeforeTimeCode)
+
+##                print "RESET"
+##            else:
+##                print
+
 
     def OnLeftDown(self, event):
         """ Handles the Left Mouse Down event """


### PR DESCRIPTION
When at the end of a transcript, if you placed a time code, then moved
off that to an earlier part of the document, the time code formatting
would get "stuck" so that new information types in would not be visible.